### PR TITLE
Tables Textcolumn : add since() format capacity

### DIFF
--- a/packages/tables/src/Columns/Concerns/CanFormatState.php
+++ b/packages/tables/src/Columns/Concerns/CanFormatState.php
@@ -38,6 +38,13 @@ trait CanFormatState
         return $this;
     }
 
+    public function since(?string $timezone = null): static
+    {
+        $this->formatStateUsing(static fn ($state): ?string => $state ? Carbon::parse($state)->setTimezone($timezone)->diffForHumans() : null);
+
+        return $this;
+    }
+    
     public function enum(array | Arrayable $options, $default = null): static
     {
         $this->formatStateUsing(static fn ($state): ?string => $options[$state] ?? ($default ?? $state));


### PR DESCRIPTION
Add the possibility to format a datetime in diffforhumans format in a textcolumn in a Filament Table